### PR TITLE
Fix: Use `tr` for compatibility with older shells

### DIFF
--- a/yt-x
+++ b/yt-x
@@ -234,7 +234,7 @@ confirm() {
   fi
 }
 launcher() {
-  case "${PREFERRED_SELECTOR,,}" in
+  case "$(echo "$PREFERRED_SELECTOR" | tr '[:upper:]' '[:lower:]')" in
   rofi)
     if [ -z "$ROFI_THEME" ]; then
       rofi -sort -matching fuzzy -dmenu -i -width 1500 -p "" -mesg "Select Action" -matching fuzzy -sorting-method fzf


### PR DESCRIPTION
Replaced `${var,,}` with `tr` to fix "bad substitution" errors in environments with older Bash versions or non-Bash shells. Ensures the script works correctly with both `fzf` and `rofi`.