### PR TITLE
refactor: use user's shell instead of bash

### DIFF
--- a/yt-x
+++ b/yt-x
@@ -994,22 +994,21 @@ ${RED}󰈆${RESET}  Exit" | launcher "Select Media Action" | sed 's/.  //g')"
       Shell)
         video_url=$(echo "$video" | jq '.url' -r)
         export url urlForAll search_results video video_url playlist_title CLI_HEADER CLI_NAME DOWNLOAD_DIRECTORY
-        bash --rcfile <(
-          cat <<'EOF'
-[ -f ~/.bashrc ] && . ~/.bashrc
-clear
-echo "$CLI_HEADER"
-echo "Welcome to the $CLI_NAME shell."
-echo "You can use the following variables:"
-echo "  - url"
-echo "  - urlForAll"
-echo "  - search_results"
-echo "  - video"
-echo "  - video_url"
-echo "  - playlist_title"
-echo "  - DOWNLOAD_DIRECTORY"
-EOF
-        )
+        local init_text="
+$CLI_HEADER
+Welcome to the $CLI_NAME shell.
+You can use the following variables:
+  - url
+  - urlForAll
+  - search_results
+  - video
+  - video_url
+  - playlist_title
+  - DOWNLOAD_DIRECTORY
+"
+
+        user_shell="$(getent passwd "$USER" | cut -d ':' -f 7)"
+        bash -c "echo -e \"$init_text\"; \"$user_shell\""
         ;;
       Exit)
         byebye


### PR DESCRIPTION
this patch allows one to use user's specified shell (from /etc/passwd) instead of bash in the video details (fzf).

~~I tried to make the script change $SHELL variable, but that meant the exported function generate_sha256 will not work.
I tried changing piping values into generate_sha256 to normal function calls, but i currently could not get it to work for the fzf and fzf preview commands.
Patches would be appreciated~~
Turns out i lost the changes
