### PR TITLE
Fix: handle rofi escape/cancel properly

### DIFF
--- a/yt-x
+++ b/yt-x
@@ -291,9 +291,11 @@ launcher() {
   case "$(echo "$PREFERRED_SELECTOR" | tr '[:upper:]' '[:lower:]')" in
   rofi)
     if [ -z "$ROFI_THEME" ]; then
-      while read -r line; do echo "$line" | sed -r 's/\x1B(\[[0-9;]*[a-zA-Z]|\(B)//g'; done | rofi -sort -matching fuzzy -dmenu -i -width 1500 -p "" -mesg "Select Action" -matching fuzzy -sorting-method fzf
+      rofiSelection=$(while read -r line; do echo "$line" | sed -r 's/\x1B(\[[0-9;]*[a-zA-Z]|\(B)//g'; done | rofi -sort -matching fuzzy -dmenu -i -width 1500 -p "" -mesg "Select Action" -matching fuzzy -sorting-method fzf)
+      [ -z "$rofiSelection" ] && echo "Exit" || echo "$rofiSelection"
     else
-      while read -r line; do echo "$line" | sed -r 's/\x1B(\[[0-9;]*[a-zA-Z]|\(B)//g'; done | rofi -no-config -theme "$ROFI_THEME" -sort -matching fuzzy -dmenu -i -width 1500 -p "" -mesg "Select Action" -matching fuzzy -sorting-method fzf
+      rofiSelection=$(while read -r line; do echo "$line" | sed -r 's/\x1B(\[[0-9;]*[a-zA-Z]|\(B)//g'; done | rofi -no-config -theme "$ROFI_THEME" -sort -matching fuzzy -dmenu -i -width 1500 -p "" -mesg "Select Action" -matching fuzzy -sorting-method fzf)
+      [ -z "$rofiSelection" ] && echo "Exit" || echo "$rofiSelection"
     fi
     ;;
   *)
@@ -498,9 +500,11 @@ launcher_with_preview() {
   case "$PREFERRED_SELECTOR" in
   rofi)
     if [ -z "$ROFI_THEME" ]; then
-      while read -r line; do echo "$line" | sed -r 's/\x1B(\[[0-9;]*[a-zA-Z]|\(B)//g'; done | rofi -sort -matching fuzzy -dmenu -i -width 1500 -p "" -mesg "$1" -matching fuzzy -sorting-method fzf
+      rofiSelection=$(while read -r line; do echo "$line" | sed -r 's/\x1B(\[[0-9;]*[a-zA-Z]|\(B)//g'; done | rofi -sort -matching fuzzy -dmenu -i -width 1500 -p "" -mesg "$1" -matching fuzzy -sorting-method fzf)
+      [ -z "$rofiSelection" ] && echo "Exit" || echo "$rofiSelection"
     else
-      while read -r line; do echo "$line" | sed -r 's/\x1B(\[[0-9;]*[a-zA-Z]|\(B)//g'; done | rofi -no-config -theme "$ROFI_THEME" -sort -matching fuzzy -dmenu -i -p "" -mesg "Select Action" -matching fuzzy -sorting-method fzf
+      rofiSelection=$(while read -r line; do echo "$line" | sed -r 's/\x1B(\[[0-9;]*[a-zA-Z]|\(B)//g'; done | rofi -no-config -theme "$ROFI_THEME" -sort -matching fuzzy -dmenu -i -p "" -mesg "Select Action" -matching fuzzy -sorting-method fzf)
+      [ -z "$rofiSelection" ] && echo "Exit" || echo "$rofiSelection"
     fi
     ;;
   *)

--- a/yt-x
+++ b/yt-x
@@ -291,11 +291,11 @@ launcher() {
   case "$(echo "$PREFERRED_SELECTOR" | tr '[:upper:]' '[:lower:]')" in
   rofi)
     if [ -z "$ROFI_THEME" ]; then
-      rofiSelection=$(while read -r line; do echo "$line" | sed -r 's/\x1B(\[[0-9;]*[a-zA-Z]|\(B)//g'; done | rofi -sort -matching fuzzy -dmenu -i -width 1500 -p "" -mesg "Select Action" -matching fuzzy -sorting-method fzf)
-      [ -z "$rofiSelection" ] && echo "Exit" || echo "$rofiSelection"
+      rofi_selection=$(while read -r line; do echo "$line" | sed -r 's/\x1B(\[[0-9;]*[a-zA-Z]|\(B)//g'; done | rofi -sort -matching fuzzy -dmenu -i -width 1500 -p "" -mesg "Select Action" -matching fuzzy -sorting-method fzf)
+      [ -z "$rofi_selection" ] && echo "Exit" || echo "$rofi_selection"
     else
-      rofiSelection=$(while read -r line; do echo "$line" | sed -r 's/\x1B(\[[0-9;]*[a-zA-Z]|\(B)//g'; done | rofi -no-config -theme "$ROFI_THEME" -sort -matching fuzzy -dmenu -i -width 1500 -p "" -mesg "Select Action" -matching fuzzy -sorting-method fzf)
-      [ -z "$rofiSelection" ] && echo "Exit" || echo "$rofiSelection"
+      rofi_selection=$(while read -r line; do echo "$line" | sed -r 's/\x1B(\[[0-9;]*[a-zA-Z]|\(B)//g'; done | rofi -no-config -theme "$ROFI_THEME" -sort -matching fuzzy -dmenu -i -width 1500 -p "" -mesg "Select Action" -matching fuzzy -sorting-method fzf)
+      [ -z "$rofi_selection" ] && echo "Exit" || echo "$rofi_selection"
     fi
     ;;
   *)
@@ -500,11 +500,11 @@ launcher_with_preview() {
   case "$PREFERRED_SELECTOR" in
   rofi)
     if [ -z "$ROFI_THEME" ]; then
-      rofiSelection=$(while read -r line; do echo "$line" | sed -r 's/\x1B(\[[0-9;]*[a-zA-Z]|\(B)//g'; done | rofi -sort -matching fuzzy -dmenu -i -width 1500 -p "" -mesg "$1" -matching fuzzy -sorting-method fzf)
-      [ -z "$rofiSelection" ] && echo "Exit" || echo "$rofiSelection"
+      rofi_selection=$(while read -r line; do echo "$line" | sed -r 's/\x1B(\[[0-9;]*[a-zA-Z]|\(B)//g'; done | rofi -sort -matching fuzzy -dmenu -i -width 1500 -p "" -mesg "$1" -matching fuzzy -sorting-method fzf)
+      [ -z "$rofi_selection" ] && echo "Exit" || echo "$rofi_selection"
     else
-      rofiSelection=$(while read -r line; do echo "$line" | sed -r 's/\x1B(\[[0-9;]*[a-zA-Z]|\(B)//g'; done | rofi -no-config -theme "$ROFI_THEME" -sort -matching fuzzy -dmenu -i -p "" -mesg "Select Action" -matching fuzzy -sorting-method fzf)
-      [ -z "$rofiSelection" ] && echo "Exit" || echo "$rofiSelection"
+      rofi_selection=$(while read -r line; do echo "$line" | sed -r 's/\x1B(\[[0-9;]*[a-zA-Z]|\(B)//g'; done | rofi -no-config -theme "$ROFI_THEME" -sort -matching fuzzy -dmenu -i -p "" -mesg "Select Action" -matching fuzzy -sorting-method fzf)
+      [ -z "$rofi_selection" ] && echo "Exit" || echo "$rofi_selection"
     fi
     ;;
   *)


### PR DESCRIPTION
Handle empty selection/escape when using rofi as preferred selector. Prevents rofi from respawning when user presses ESC to exit program.