### PR TITLE
fix: exit rofi search on empty string or esc

### DIFF
--- a/yt-x
+++ b/yt-x
@@ -1366,7 +1366,7 @@ ${RED}󰈆${RESET}  Exit" | launcher "Select Action" | sed 's/.*  //g')"
     clear
     if [ -z "$CMD_SEARCH_TERMS" ]; then
            search_term="$(prompt "Enter term to search for")"
-      # Exit if user submits an empty search term in rofi
+      # Exit if user presses ESC or leaves search empty in rofi
       if [ "$PREFERRED_SELECTOR" = "rofi" ] && [ -z "$search_term" ]; then
         echo "Search canceled. No search term provided."
         return 1

--- a/yt-x
+++ b/yt-x
@@ -1365,7 +1365,12 @@ ${RED}󰈆${RESET}  Exit" | launcher "Select Action" | sed 's/.*  //g')"
   Search)
     clear
     if [ -z "$CMD_SEARCH_TERMS" ]; then
-      search_term="$(prompt "Enter term to search for")"
+           search_term="$(prompt "Enter term to search for")"
+      # Exit if user submits an empty search term in rofi
+      if [ "$PREFERRED_SELECTOR" = "rofi" ] && [ -z "$search_term" ]; then
+        echo "Search canceled. No search term provided."
+        return 1
+      fi
     else
       search_term="$CMD_SEARCH_TERMS"
       unset CMD_SEARCH_TERMS


### PR DESCRIPTION
Applies the same treatment as #43 in rofi search 