### PR TITLE
fix: ctrl-c or esc should escape, not say invalid action

### DIFF
--- a/yt-x
+++ b/yt-x
@@ -751,7 +751,7 @@ playlist_explorer() {
     "Main Menu")
       break
       ;;
-    Back)
+    Back|"")
       break
       ;;
     Exit)
@@ -1151,7 +1151,7 @@ ${RED}󰈆${RESET}  Exit" | launcher "Select Media Action" | sed 's/.  //g')"
         yt-dlp "$video_url" -x -f 'bestaudio' --audio-format mp3 --output "$DOWNLOAD_DIRECTORY/audio/individual/%(channel)s/%(title)s.%(ext)s" $PREFERRED_BROWSER
         send_notification "Completed downloading $title"
         ;;
-      Back)
+      Back|"")
         break
         ;;
       Shell)
@@ -1237,7 +1237,7 @@ playlists_explorer() {
     clear
     playlist_title="$(echo "$playlist_title" | sed 's/"/\\"/g')"
     case "$playlist_title" in
-    *Back)
+    *Back|"")
       break
       ;;
     *Exit)
@@ -1267,7 +1267,7 @@ ${CYAN}󰌍${RESET}  Back
 ${RED}󰈆${RESET}  Exit
 " | launcher "Select Action" | sed 's/.  //g')"
     [ "$channel_action" = "Exit" ] && byebye
-    [ "$channel_action" = "Back" ] && break
+    [ "$channel_action" = "Back" ] || [ "$channel_action" = "" ] && break
     uploader_url_base="$(echo "$channel" | jq '.uploader_url' -r)"
 
     case "$channel_action" in
@@ -1432,7 +1432,7 @@ ${RED}󰈆${RESET}  Exit" | launcher "Select Action" | sed 's/.*  //g')"
     ! [ -s "$CUSTOM_PLAYLISTS" ] && echo "You dont have any custom playlists create them here <$CUSTOM_PLAYLISTS>" && sleep "$NOTIFICATION_DURATION" && main
     while true; do
       playlist_title=$(printf "%s\nBack" "$(jq -r '.|reverse|.[].name' "$CUSTOM_PLAYLISTS")" | launcher "Select Custom Playlist To Play")
-      [ "$playlist_title" = "Back" ] && break
+      [ "$playlist_title" = "Back" ] || [ "$playlist_title" = "" ] && break
       url=$(jq -r ". | map(select(.name == \"$playlist_title\" )) | .[0].playlistWatchUrl" "$CUSTOM_PLAYLISTS")
       urlForAll=$(jq -r ". | map(select(.name == \"$playlist_title\" )) | .[0].playlistUrl" "$CUSTOM_PLAYLISTS")
       search_results=$(run_yt_dlp "$url")
@@ -1508,7 +1508,7 @@ ${RED}󰈆${RESET}  Exit
           channel_name=$(printf "%s\nBack\nExit" "$channels" | launcher_with_preview "Select Channel" "$PREVIEW_SCRIPT_FOR_CHANNELS_EXPLORER")
           channel_name="$(echo "$channel_name" | sed 's/"/\\"/g;s/ *$//g' | tr -d "\n")"
           [ "$channel_name" = "Exit" ] && byebye
-          [ "$channel_name" = "Back" ] && break
+          [ "$channel_name" = "Back" ] || [ "$channel_name" = "" ] && break
           channel="$(echo "$channels_data" | jq ".entries|map(select(.channel == \"$channel_name\"))|.[0]")"
           channels_explorer
         done
@@ -1527,7 +1527,7 @@ ${RED}󰈆${RESET}  Exit
         while true; do
           ! [ -s "$CLI_CACHE_DIR/search_history.txt" ] && echo "No search history or disabed" && sleep "$NOTIFICATION_DURATION" && main
           search_term="$(printf "$(tac "$CLI_CACHE_DIR/search_history.txt")\nBack" | launcher "Search for" | jq -Rr '@uri')"
-          [ "$search_term" = "Back" ] && break
+          [ "$search_term" = "Back" ] || [ "$search_term" = "" ] && break
           url="https://www.youtube.com/results?search_query=$search_term&sp=EgIQAQ%253D%253D"
           search_results=$(run_yt_dlp "$url")
           playlist_explorer
@@ -1563,7 +1563,7 @@ ${RED}󰈆${RESET}  Exit
         ! [ -s "$F_CUSTOM_CMDS" ] && send_notification "You dont have any custom cmds create them here <$F_CUSTOM_CMDS>"
         while true; do
           custom_cmd_name=$(printf "%s\nBack" "$(jq -r '.[].name' "$F_CUSTOM_CMDS")" | launcher "Select Custom Data Loader Command To Run")
-          [ "$custom_cmd_name" = "Back" ] && break
+          [ "$custom_cmd_name" = "Back" ] || [ "$custom_cmd_name" = "" ] && break
           custom_yt_dlp_cmd=$(jq -r ". | map(select(.name == \"$custom_cmd_name\" )) | .[0].cmd" "$F_CUSTOM_CMDS")
           echo Running custom command...
           search_results=$(
@@ -1646,7 +1646,7 @@ ${RED}󰈆${RESET}  Exit
           send_notification "Sync cancelled"
         fi
         ;;
-      Back)
+      Back|"")
         break
         ;;
       Exit)
@@ -1659,7 +1659,7 @@ ${RED}󰈆${RESET}  Exit
       esac
     done
     ;;
-  Exit)
+  Exit|"")
     byebye
     ;;
   *)


### PR DESCRIPTION
Is there a reason "" counts as invalid action?

<del>edit: I realized that "" should probably go back if that's an option, instead of exiting all together</del> fixed