### PR TITLE
chore: updating flake.lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,11 @@ nix profile install github:Benexl/yt-x
 
     ```nix
     inputs = {
-      yt-x.url = "github:Benexl/yt-x";
+      nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+      yt-x = {
+        url = "github:Benexl/yt-x";
+        inputs.nixpkgs.follows = "nixpkgs";
+      };
       ...
     }
     ```

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1732014248,
-        "narHash": "sha256-y/MEyuJ5oBWrWAic/14LaIr/u5E0wRVzyYsouYY3W6w=",
+        "lastModified": 1749143949,
+        "narHash": "sha256-QuUtALJpVrPnPeozlUG/y+oIMSLdptHxb3GK6cpSVhA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+        "rev": "d3d2d80a2191a73d1e86456a751b83aa13085d7d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updating the flake.lock so that yt-x uses the up-to date version of yt-dlp in NixOS or systems managed by nix, this closes #60.
Also updated the installation method for NixOS in the readme that better handles this issue and doesn't depend on having the lock file updated in this repo everytime yt-dlp breaks upstream