### PR TITLE
Remove quotations around timestamp calculation

### DIFF
--- a/yt-x
+++ b/yt-x
@@ -406,7 +406,7 @@ generate_text_preview() {
 
     # some date calculations
     timestamp=$(echo "$video" | jq '.timestamp' -r)
-    relative_timestamp=$(("$CURRENT_TIME" - "$timestamp"))
+    relative_timestamp=$(($CURRENT_TIME - $timestamp))
     if [ "$relative_timestamp" -lt 60 ]; then
       timestamp="just now"
     elif [ "$relative_timestamp" -lt 3600 ]; then


### PR DESCRIPTION
Quotation marks around a timestamp calculation were causing an error message when running yt-x on MacOS 14.5, kitty terminal, zsh shell, so I removed them. Error message is gone and everything seems to work.  

Let me know if you have any questions or if you know a reason for those quotes. 