### PR TITLE
fix: replace $USERNAME with $USER for reliability

### DIFF
--- a/yt-x
+++ b/yt-x
@@ -550,7 +550,7 @@ init_pretty_print() {
 }
 byebye() {
   clear
-  echo "Have a good day $USERNAME"
+  echo "Have a good day $USER"
   exit "${1:-0}"
 }
 prompt() {


### PR DESCRIPTION
$USERNAME is only set by bash in interactive login shells, so it may be unset when the function runs in a non-interactive context. Resulting in the program just exitting with "Have a good day " without displaying the username. $USER, on the other hand, is exported by the environment at login and is consistently available to scripts.

Replaced $USERNAME with $USER to ensure theusername is always shown.

Tested on Linux 6.16.1-arch1-1 GNU bash, version 5.3.3(1)-release