### PR TITLE
Extended search functionalities and various typo fixes

### DIFF
--- a/yt-x
+++ b/yt-x
@@ -1466,7 +1466,6 @@ ${RED}󰈆${RESET}  Exit" | launcher "Select Action" | sed 's/.*  //g')"
     [ "$SEARCH_HISTORY" = "true" ] && echo "$search_term" >>"$CLI_CACHE_DIR/search_history.txt"
     search_term=$(echo "$search_term" | jq -Rr '@uri')
     url="https://www.youtube.com/results?search_query=$search_term&sp=$sp"
-    echo $url
     search_results=$(run_yt_dlp "$url")
     playlist_explorer
     ;;

--- a/yt-x
+++ b/yt-x
@@ -377,7 +377,9 @@ generate_text_preview() {
     )
 
     live_status=$(echo "$video" | jq '.live_status' -r)
-    [ "$live_status" = "null" ] && live_status='false'
+    [ "$live_status" = "is_live" ] && live_status='Online'
+    [ "$live_status" = "was_live" ] && live_status='Offline'
+    [ "$live_status" = "null" ] && live_status='False'
 
     description=$(echo "$video" | jq '.description' -r | sed "s/\"//g;s/%//g")
     channel=$(echo "$video" | jq '.channel' -r)

--- a/yt-x
+++ b/yt-x
@@ -557,12 +557,12 @@ byebye() {
 }
 prompt() {
   HISTORY=$(tail -n 10 "$CLI_CACHE_DIR/search_history.txt" | grep -v '^\s*$' | tac | nl -w2 -s'. ')
-  HISTORY_TEXT="\nSearch history:\n$HISTORY\n-----------------------------\n(Enter !<n> for selecting from history. Example: !1)\n "
+  HISTORY_TEXT="Enter !<command> <query> for extended search\nFilter by upload date: !hour, !today, !week, !month, !year\nFilter by content: !video, !movie, !live, !4k, !hd\nSort videos by !newest, !views, !rating\n-----------------------------\nSearch history:\n$HISTORY\n-----------------------------\n(Enter !<n> to select from history. Example: !1)\n"
   if [ "$PREFERRED_SELECTOR" = "rofi" ]; then
     if [ "$PROMPT_CONTEXT" = "Search" ] && [ "$SEARCH_HISTORY" = "true" ] && [ -n "$HISTORY" ]; then
       rofi -dmenu \
         -p "$1" \
-        -mesg "$(printf "\nSearch history:\n%s\n(Enter !&lt;n&gt; for selecting from history. Example: !1)\n" "$HISTORY")" \
+        -mesg "$(printf "\nSearch history:\n%s\n(Enter !&lt;n&gt; to select from history. Example: !1)\n" "$HISTORY")" \
         <<< "" 
       PROMPT_CONTEXT=""
     else
@@ -1418,9 +1418,43 @@ ${RED}󰈆${RESET}  Exit" | launcher "Select Action" | sed 's/.*  //g')"
             echo "No such history item: $index"
           fi
         fi
+        if [[ "$search_term" =~ ^(![a-z]+)[[:space:]]+(.+) ]]; then
+          search_filter="${BASH_REMATCH[1]}"
+          search_term="${BASH_REMATCH[2]}"
+          case "$search_filter" in
+            "!hour") sp="EgIIAQ%253D%253D"
+              ;;
+            "!today") sp="EgIIAg%253D%253D"
+              ;;
+            "!week") sp="EgIIAw%253D%253D"
+              ;;
+            "!month") sp="EgIIBA%253D%253D"
+              ;;
+            "!year") sp="EgIIBQ%253D%253D"
+              ;;
+            "!video") sp="EgIQAQ%253D%253D"
+              ;;
+            "!movie") sp="EgIQBA%253D%253D"
+              ;;
+            "!live") sp="EgJAAQ%253D%253D"
+              ;;
+            "!4k") sp="EgJwAQ%253D%253D"
+              ;;
+            "!hd") sp="EgIgAQ%253D%253D"
+              ;;
+            "!newest") sp="CAISAhAB"
+              ;;
+            "!views") sp="CAMSAhAB"
+              ;;
+            "!rating") sp="CAESAhAB"
+              ;;
+            *) sp="EgIQAQ%253D%253D"
+              ;;
+          esac
+        fi
       # Exit if user presses ESC or leaves search empty in rofi
       if [ "$PREFERRED_SELECTOR" = "rofi" ] && [ -z "$search_term" ]; then
-        echo "Search canceled. No search term provided."
+        echo "Search cancelled. No search term provided."
         return 1
       fi
     else
@@ -1431,7 +1465,8 @@ ${RED}󰈆${RESET}  Exit" | launcher "Select Action" | sed 's/.*  //g')"
     [ "$SEARCH_HISTORY" = "true" ] && [ -s "$CLI_CACHE_DIR/search_history.txt" ] && echo "$history" >$CLI_CACHE_DIR/search_history.txt
     [ "$SEARCH_HISTORY" = "true" ] && echo "$search_term" >>"$CLI_CACHE_DIR/search_history.txt"
     search_term=$(echo "$search_term" | jq -Rr '@uri')
-    url="https://www.youtube.com/results?search_query=$search_term&sp=EgIQAQ%253D%253D"
+    url="https://www.youtube.com/results?search_query=$search_term&sp=$sp"
+    echo $url
     search_results=$(run_yt_dlp "$url")
     playlist_explorer
     ;;

--- a/yt-x
+++ b/yt-x
@@ -229,7 +229,7 @@ check_update() {
   update=$(curl -s "https://raw.githubusercontent.com/Benexl/yt-x/refs/heads/master/yt-x")
   update="$(printf '%s\n' "$update" | diff -u "$(command -v yt-x)" - 2>/dev/null)"
   if [ -n "$update" ]; then
-    confirm "An update has been found would you like to see the changes before deciding whether to update" && echo "$update" | less
+    confirm "An update has been found would you like to see the changes before deciding whether to update?" && echo "$update" | less
     if [ "$PREFERRED_SELECTOR" = "fzf" ]; then
       answer=$(prompt "$1")
     else
@@ -953,7 +953,7 @@ ${RED}󰈆${RESET}  Exit" | launcher "Select Media Action" | sed 's/.  //g')"
           yt_dlp_cmd=("yt-dlp" "$url" "--output" "$DOWNLOAD_DIRECTORY/videos/$playlist_name/%(channel)s/$enumerate_playlist%(title)s.%(ext)s" $PREFERRED_BROWSER)
           "${yt_dlp_cmd[@]}" --download-archive "$CLI_YT_DLP_ARCHIVE/$(echo -n -- "${yt_dlp_cmd[@]}" | generate_sha256)"
         fi
-        send_notification "Completed downloading $playlist_name"
+        send_notification "Completed downloading of $playlist_name"
         ;;
       "Download All (Audio Only)")
         playlist_name=$(prompt "Name of the playlist" "$playlist_title")
@@ -965,7 +965,7 @@ ${RED}󰈆${RESET}  Exit" | launcher "Select Media Action" | sed 's/.  //g')"
           yt_dlp_cmd=("yt-dlp" "$url" "--audio-format" "mp3" '-x' '-f' 'bestaudio/best' "--output" "$DOWNLOAD_DIRECTORY/audio/$playlist_name/%(channel)s/$enumerate_playlist%(title)s.%(ext)s" $PREFERRED_BROWSER)
           "${yt_dlp_cmd[@]}" --download-archive "$CLI_YT_DLP_ARCHIVE/$(echo -n -- "${yt_dlp_cmd[@]}" | generate_sha256)"
         fi
-        send_notification "Completed downloading $playlist_name"
+        send_notification "Completed downloading of $playlist_name"
         ;;
       Listen)
         printf "${MAGENTA}Now Listening to:${RESET} $title\n"
@@ -1150,12 +1150,13 @@ ${RED}󰈆${RESET}  Exit" | launcher "Select Media Action" | sed 's/.  //g')"
         ;;
       "Subscribe To Channel")
         # TODO: use youtube api to enable video subscriptions
-        echo contribute to the project by adding this feature
+        send_notification "contribute to the project by adding this feature"
         sleep "$NOTIFICATION_DURATION"
         ;;
       "Visit Channel")
         # TODO: use youtube api to enable video subscriptions
         send_notification "contribute to the project by adding this feature"
+        sleep "$NOTIFICATION_DURATION"
         ;;
       "Open in Browser")
         if command -v "open" >/dev/null 2>&1; then
@@ -1169,12 +1170,12 @@ ${RED}󰈆${RESET}  Exit" | launcher "Select Media Action" | sed 's/.  //g')"
       Download)
         video_url=$(echo "$video" | jq '.url' -r)
         yt-dlp "$video_url" --output "$DOWNLOAD_DIRECTORY/videos/individual/%(channel)s/%(title)s.%(ext)s" $PREFERRED_BROWSER
-        send_notification "Completed downloading $title"
+        send_notification "Completed downloading of $title"
         ;;
       "Download (Audio Only)")
         video_url=$(echo "$video" | jq '.url' -r)
         yt-dlp "$video_url" -x -f 'bestaudio' --audio-format mp3 --output "$DOWNLOAD_DIRECTORY/audio/individual/%(channel)s/%(title)s.%(ext)s" $PREFERRED_BROWSER
-        send_notification "Completed downloading $title"
+        send_notification "Completed downloading of $title"
         ;;
       Back|"")
         break
@@ -1228,7 +1229,7 @@ get_channels_data() {
     channels_data=$(cat "$CLI_CONFIG_DIR/subscriptions.json")
   else
     echo Loading subscriptions...
-    [ -n "$PREFERRED_BROWSER" ] && channels_data=$(yt-dlp "https://www.youtube.com/feed/channels" --flat-playlist $PREFERRED_BROWSER -J) || send_notification "Failed to fetch subscriptions (please set preferred browser in config"
+    [ -n "$PREFERRED_BROWSER" ] && channels_data=$(yt-dlp "https://www.youtube.com/feed/channels" --flat-playlist $PREFERRED_BROWSER -J) || send_notification "Failed to fetch subscriptions (please set preferred browser in config)"
     ! [ "$FORCE_CHANNEL_THUMBNAILS_DOWNLOAD" = "0" ] && [ "$ENABLE_PREVIEW" = "true" ] && download_preview_images "$channels_data" "https:"
     [ -n "$channels_data" ] && ! [ "$channels_data" = "null" ] && echo "$channels_data" >"$CLI_CONFIG_DIR/subscriptions.json" || send_notification "Failed to fetch subscriptions"
     clear
@@ -1332,7 +1333,7 @@ ${RED}󰈆${RESET}  Exit
       ;;
     Subscribe)
       if ! [ -s "$CLI_CONFIG_DIR/subscriptions.json" ]; then
-        if confirm "Would you like to import your youtube subscriptions first; you wont be able to do so again unless you delete the subscribtiofile"; then
+        if confirm "Would you like to import your youtube subscriptions first? You wont be able to do so again unless you delete subscriptions.json"; then
           _channels_data=$(yt-dlp "https://www.youtube.com/feed/channels" --flat-playlist $PREFERRED_BROWSER -J)
           echo "$_channels_data" >"$CLI_CONFIG_DIR/subscriptions.json"
         else
@@ -1465,7 +1466,7 @@ ${RED}󰈆${RESET}  Exit" | launcher "Select Action" | sed 's/.*  //g')"
     done
     ;;
   Custom\ Playlists)
-    ! [ -s "$CUSTOM_PLAYLISTS" ] && echo "You dont have any custom playlists create them here <$CUSTOM_PLAYLISTS>" && sleep "$NOTIFICATION_DURATION" && main
+    ! [ -s "$CUSTOM_PLAYLISTS" ] && echo "You don't have any custom playlists. Create them here: <$CUSTOM_PLAYLISTS>" && sleep "$NOTIFICATION_DURATION" && main
     while true; do
       playlist_title=$(printf "%s\nBack" "$(jq -r '.|reverse|.[].name' "$CUSTOM_PLAYLISTS")" | launcher "Select Custom Playlist To Play")
       [ "$playlist_title" = "Back" ] || [ "$playlist_title" = "" ] && break
@@ -1532,7 +1533,7 @@ ${RED}󰈆${RESET}  Exit
         unset search_term
         while true; do
           clear
-          [ -z "$search_term" ] && search_term=$(prompt "What channel would you like to explore") && url="https://www.youtube.com/results?search_query=$search_term&sp=EgIQAg%253D%253D" && channels_data=$(
+          [ -z "$search_term" ] && search_term=$(prompt "What channel would you like to explore?") && url="https://www.youtube.com/results?search_query=$search_term&sp=EgIQAg%253D%253D" && channels_data=$(
             if command -v "gum" >/dev/null 2>&1; then
               gum spin --show-output -- yt-dlp "$url" -J --flat-playlist --extractor-args youtubetab:approximate_date $PREFERRED_BROWSER --playlist-start 1 --playlist-end $NO_OF_SEARCH_RESULTS
             else
@@ -1554,7 +1555,7 @@ ${RED}󰈆${RESET}  Exit
         ;;
       Explore\ Playlists)
         clear
-        search_term=$(prompt "What playlist would you like to explore")
+        search_term=$(prompt "What playlist would you like to explore?")
         url="https://www.youtube.com/results?search_query=$search_term&sp=EgIQAw%253D%253D"
         PLAYLISTS_EXTRA_ARGS="--playlist-start 1 --playlist-end $NO_OF_SEARCH_RESULTS"
         playlists_explorer
@@ -1598,7 +1599,7 @@ ${RED}󰈆${RESET}  Exit
         playlist_explorer
         ;;
       Custom\ Commands)
-        ! [ -s "$F_CUSTOM_CMDS" ] && send_notification "You dont have any custom cmds create them here <$F_CUSTOM_CMDS>"
+        ! [ -s "$F_CUSTOM_CMDS" ] && send_notification "You dont have any custom cmds. Create them here: <$F_CUSTOM_CMDS>"
         while true; do
           custom_cmd_name=$(printf "%s\nBack" "$(jq -r '.[].name' "$F_CUSTOM_CMDS")" | launcher "Select Custom Data Loader Command To Run")
           [ "$custom_cmd_name" = "Back" ] || [ "$custom_cmd_name" = "" ] && break
@@ -1682,10 +1683,10 @@ ${RED}󰈆${RESET}  Exit
         fi
         ;;
       Clear\ Search\ History)
-        confirm "Are you sure you want to clear your search history ($CLI_CACHE_DIR/search_history.txt)" && rm "$CLI_CACHE_DIR/search_history.txt"
+        confirm "Are you sure you want to clear your search history ($CLI_CACHE_DIR/search_history.txt)?" && rm "$CLI_CACHE_DIR/search_history.txt"
         ;;
       Sync\ YouTube\ Subscriptions)
-        if confirm "This will erase your local subs, are you sure you wish to proceed"; then
+        if confirm "This will erase your local subs, proceed?"; then
           echo "Syncing subscriptions..."
           [ -n "$PREFERRED_BROWSER" ] && channels_data=$(yt-dlp "https://www.youtube.com/feed/channels" --flat-playlist $PREFERRED_BROWSER -J) || send_notification "Failed to fetch subscriptions (please set preferred browser in config"
           download_preview_images "$channels_data" "https:"
@@ -1799,7 +1800,7 @@ while [ $# -gt 0 ]; do
     byebye
     ;;
   -U | --update)
-    check_update "A new version of $CLI_NAME has been found would you like to upgrade(y/n)"
+    check_update "A new version of $CLI_NAME has been found would you like to upgrade? (y/n)"
     exit 0
     ;;
   -S | --search)
@@ -1959,7 +1960,7 @@ if [ "$UPDATE_CHECK" = "true" ]; then
   last_check_time=$(cat "$timestamp_file" 2>/dev/null || echo 0)
 
   if ((current_time - last_check_time >= interval)); then
-    check_update "A new version of $CLI_NAME has been found would you like to upgrade(y/n)"
+    check_update "A new version of $CLI_NAME has been found would you like to upgrade? (y/n)"
     echo "$current_time" >"$timestamp_file"
   fi
 fi


### PR DESCRIPTION
- **Fixed typos**
Just added some punctuation, closed parentheses, and some rewording to make it a little bit clearer.
- **Made the Live Status a little bit prettier**
Instead of is_live and was_line, a simple conversion to Online and Offline makes it slighty better.
- **Added extended search parameters**
Using the [sp parameter](https://serpapi.com/blog/youtube-sp-filters-paginating-sorting-and-filtering-with-the-youtube-api/), you can now prefix your search query like so: `!<command> <search_query>` to make more precise searches. I've currently implemented filters for upload date (**!hour**, **!today**, **!week**, **!month**, **!year**), content type (**!live**, **!4k**, **!hd**, **!video**, **!movie**), and sorting by date with **!newest**, by view count with **!views**, and by rating with **!rating**. I've added a little help dialog above the search history, it might not show up while using `rofi` though..
Note that you cannot "chain" multiple filters using this method, so can't filter by date and sort by view count for example, that would require to modify the `yt-dlp` command itself.
Also, I didn't include the whole query in the history as to not add confusion, but it might be worth adding it, who knows?

Seems to work just fine so far, but feel free to test and add changes!
