### PR TITLE
Fleshed out extended search & README

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,44 +268,36 @@ export YT_X_FZF_OPTS=$FZF_DEFAULT_OPTS'
 ```
 
 ## Extended search
- While searching, you can prefix your query with a `!command` to filter your search request: `!<command> your_query`. Only one command can be used per query.
+ While searching, you can prefix your query with a `:command` to filter your search request: `:<command> your_query`. Only one command can be used per query.
 
 ### List of commands
 
 | Command        | Description                                |
 |----------------|--------------------------------------------|
-| `!live`        | Show only live streams                     |
-| `!today`       | Videos uploaded today                      |
-| `!week`        | Videos uploaded this week                  |
-| `!month`       | Videos uploaded this month                 |
-| `!year`        | Videos uploaded this year                  |
-| `!short`       | Short videos (< 4 minutes)                 |
-| `!long`        | Long videos (> 4 minutes)                  |
-| `!playlist`    | Show playlists only                        |
-| `!movie`       | Movies                                     |
-| `!hd`          | HD videos                                  |
-| `!4k`          | 4K videos                                  |
-| `!hdr`         | HDR videos                                 |
-| `!subtitles`   | Videos with subtitles/CC                   |
-| `!360`         | 360° videos                                |
-| `!vr`          | VR180 videos                               |
-| `!3d`          | 3D videos                                  |
-| `!local`       | Videos filtered by location                |
+| `:live`        | Show only live streams                     |
+| `:today`       | Videos uploaded today                      |
+| `:week`        | Videos uploaded this week                  |
+| `:month`       | Videos uploaded this month                 |
+| `:year`        | Videos uploaded this year                  |
+| `:short`       | Short videos (< 4 minutes)                 |
+| `:long`        | Long videos (> 4 minutes)                  |
+| `:playlist`    | Show playlists only                        |
+| `:movie`       | Movies                                     |
+| `:hd`          | HD videos                                  |
+| `:4k`          | 4K videos                                  |
+| `:hdr`         | HDR videos                                 |
+| `:subtitles`   | Videos with subtitles/CC                   |
+| `:360`         | 360° videos                                |
+| `:vr`          | VR180 videos                               |
+| `:3d`          | 3D videos                                  |
+| `:local`       | Videos filtered by location                |
 
 ### Sorting Options
 | Command        | Description                                |
 |----------------|--------------------------------------------|
-| `!views`       | Sort results by view count                 |
-| `!rating`      | Sort results by rating                     |
-| `!newest`      | Sort results by upload date                |
-
-### Combined Options
-| Command         | Description                                |
-|-----------------|--------------------------------------------|
-| `!todaybest`  | Today’s videos sorted by view count        |
-| `!weekbest`   | This week’s videos sorted by view count    |
-| `!monthbest`  | This month’s videos sorted by view count   |
-| `!yearbest`   | This year’s videos sorted by view count    |
+| `:views`       | Sort results by view count                 |
+| `:rating`      | Sort results by rating                     |
+| `:newest`      | Sort results by upload date                |
 
 ## Other Terminal Browsers I Made
 [lib-x](https://github.com/Benexl/lib-x) - browse your calibre library from the terminal

--- a/yt-x
+++ b/yt-x
@@ -557,7 +557,7 @@ byebye() {
 }
 prompt() {
   HISTORY=$(tail -n 10 "$CLI_CACHE_DIR/search_history.txt" | grep -v '^\s*$' | tac | nl -w2 -s'. ')
-  HISTORY_TEXT="Enter !<command> <query> for extended search\nFilter by upload date (add best at the end to sort by view count): !hour[best], !today[best], !week[best], !month[best], !year[best]\nFilter by content: !video, !movie, !live\n Filter by features: !hd, !4k, !hdr, !subtitles, !360, !vr, !3d, !local\nSort videos by !newest, !views, !rating\n-----------------------------\nSearch history:\n$HISTORY\n-----------------------------\n(Enter !<n> to select from history. Example: !1)\n"
+  HISTORY_TEXT="Enter :<command> <query> for extended search\nFilter by upload date - :hour, :today, :week, :month, :year\nFilter by content - :video, :movie, :live\n Filter by features - :hd, :4k, :hdr, :subtitles, :360, :vr, :3d, :local\nSort videos by - :newest, :views, :rating\n-----------------------------\nSearch history:\n$HISTORY\n-----------------------------\n(Enter !<n> to select from history. Example: !1)\n"
   if [ "$PREFERRED_SELECTOR" = "rofi" ]; then
     if [ "$PROMPT_CONTEXT" = "Search" ] && [ "$SEARCH_HISTORY" = "true" ] && [ -n "$HISTORY" ]; then
       rofi -dmenu \
@@ -1418,38 +1418,6 @@ ${RED}󰈆${RESET}  Exit" | launcher "Select Action" | sed 's/.*  //g')"
             echo "No such history item: $index"
           fi
         fi
-        if [[ "$search_term" =~ ^(![a-z]+)[[:space:]]+(.+) ]]; then
-          search_filter="${BASH_REMATCH[1]}"
-          search_term="${BASH_REMATCH[2]}"
-          case "$search_filter" in
-            "!hour")        sp="EgIIAQ%253D%253D" ;;
-            "!today")       sp="EgIIAg%253D%253D" ;;
-            "!week")        sp="EgIIAw%253D%253D" ;;
-            "!month")       sp="EgIIBA%253D%253D" ;;
-            "!year")        sp="EgIIBQ%253D%253D" ;;
-            "!todaybest")   sp="EgQIARAB%252C%252CCAM%253D" ;;
-            "!weekbest")    sp="EgQIAhAB%252C%252CCAM%253D" ;;
-            "!monthbest")   sp="EgQIAxAB%252C%252CCAM%253D" ;;
-            "!yearbest")    sp="EgQIBBAB%252C%252CCAM%253D" ;;
-            "!video")       sp="EgIQAQ%253D%253D" ;;
-            "!movie")       sp="EgIQBA%253D%253D" ;;
-            "!live")        sp="EgJAAQ%253D%253D" ;;
-            "!short")       sp="EgQQARgB" ;;
-            "!long")        sp="EgQQARgC" ;;
-            "!4k")          sp="EgJwAQ%253D%253D" ;;
-            "!hd")          sp="EgIgAQ%253D%253D" ;;
-            "!subtitles")   sp="EgIoAQ%253D%253D" ;;
-            "!360")         sp="EgJ4AQ%253D%253D" ;;
-            "!vr")          sp="EgLIAQ%253D%253D" ;;
-            "!3d")          sp="EgI4AQ%253D%253D" ;;
-            "!hdr")         sp="EgPIAQ%253D%253D" ;;
-            "!local")       sp="EgO4AQ%253D%253D" ;;
-            "!newest")      sp="CAISAhAB" ;;
-            "!views")       sp="CAMSAhAB" ;;
-            "!rating")      sp="CAESAhAB" ;;
-            *)              sp="EgIQAQ%253D%253D" ;;
-          esac
-        fi
       # Exit if user presses ESC or leaves search empty in rofi
       if [ "$PREFERRED_SELECTOR" = "rofi" ] && [ -z "$search_term" ]; then
         echo "Search cancelled. No search term provided."
@@ -1458,6 +1426,34 @@ ${RED}󰈆${RESET}  Exit" | launcher "Select Action" | sed 's/.*  //g')"
     else
       search_term="$CMD_SEARCH_TERMS"
       unset CMD_SEARCH_TERMS
+    fi
+    if [[ "$search_term" =~ ^(:[a-z]+)[[:space:]]+(.+) ]]; then
+      search_filter="${BASH_REMATCH[1]}"
+      search_term="${BASH_REMATCH[2]}"
+      case "$search_filter" in
+        ":hour")        sp="EgIIAQ%253D%253D" ;;
+        ":today")       sp="EgIIAg%253D%253D" ;;
+        ":week")        sp="EgIIAw%253D%253D" ;;
+        ":month")       sp="EgIIBA%253D%253D" ;;
+        ":year")        sp="EgIIBQ%253D%253D" ;;
+        ":video")       sp="EgIQAQ%253D%253D" ;;
+        ":movie")       sp="EgIQBA%253D%253D" ;;
+        ":live")        sp="EgJAAQ%253D%253D" ;;
+        ":short")       sp="EgQQARgB" ;;
+        ":long")        sp="EgQQARgC" ;;
+        ":4k")          sp="EgJwAQ%253D%253D" ;;
+        ":hd")          sp="EgIgAQ%253D%253D" ;;
+        ":subtitles")   sp="EgIoAQ%253D%253D" ;;
+        ":360")         sp="EgJ4AQ%253D%253D" ;;
+        ":vr")          sp="EgLIAQ%253D%253D" ;;
+        ":3d")          sp="EgI4AQ%253D%253D" ;;
+        ":hdr")         sp="EgPIAQ%253D%253D" ;;
+        ":local")       sp="EgO4AQ%253D%253D" ;;
+        ":newest")      sp="CAISAhAB" ;;
+        ":views")       sp="CAMSAhAB" ;;
+        ":rating")      sp="CAESAhAB" ;;
+        *)              sp="EgIQAQ%253D%253D" ;;
+      esac
     fi
     [ "$SEARCH_HISTORY" = "true" ] && [ -s "$CLI_CACHE_DIR/search_history.txt" ] && history=$(grep --invert-match "^$search_term\$" "$CLI_CACHE_DIR/search_history.txt")
     [ "$SEARCH_HISTORY" = "true" ] && [ -s "$CLI_CACHE_DIR/search_history.txt" ] && echo "$history" >$CLI_CACHE_DIR/search_history.txt


### PR DESCRIPTION
- **Modified README.md to include extended search options**
Added instructions on how to use extended search and a table detailing each sp parameter 
- **Added every useful sp parameter to the extended search, along with some combined search presets**
Added the following commands :

`!short` : Short videos (< 4 minutes)  
`!long` : Long videos (> 4 minutes) 
`!hdr` : HDR videos      
`!subtitles` : Videos with subtitles/CC     
`!360` : 360° videos   
`!vr` : VR180 videos   
`!3d` : 3D videos   
`!local` : Videos filtered by location   
`!todaybest` : Today’s videos sorted by view count    
`!weekbest` : This week’s videos sorted by view count  
`!monthbest` : This month’s videos sorted by view count 
`!yearbest` : This year’s videos sorted by view count  

All seems to work, except `!views` and `!<date>best`, which does seem to show videos with high view counts but they're not ordered (it's definitively different from regular `!<date>` queries). Might be an issue on how `yt-dlp` fetches and orders videos itself.
Still, somewhat useful!
