### PR TITLE
fix: strip &start_radio=1 to restore full YouTube Mix playback

### DIFF
--- a/yt-x
+++ b/yt-x
@@ -814,6 +814,9 @@ ${RED}󰈆${RESET}  Exit" | launcher "Select Media Action" | sed 's/.  //g')"
       "Play All")
         if echo "$url" | grep -q "list=RD" || echo "$urlForAll" | grep -q "list=RD" || [ "$(echo "$search_results" | jq 'has("uploader_url") | not')" = "true" ]; then
           if [ -n "$urlForAll" ]; then
+            # Fix YouTube Mix URLs FIRST
+            url="${url/&start_radio=0/}"
+            urlForAll="${urlForAll/&start_radio=1/}"
             cached_playlist="$CLI_AUTO_GEN_PLAYLISTS/$(generate_sha256 "$urlForAll").m3u8"
             if ! [ -s "$cached_playlist" ]; then
               _mix_data=$(yt-dlp "$urlForAll" --flat-playlist -J)


### PR DESCRIPTION
Hi @Benexl 👋

This PR fixes an issue where YouTube Mix (list=RD…) URLs that contain the
`&start_radio=1` or `&start_radio=0` parameter only play a single video in
yt-x instead of expanding into the full Mix playlist.

### 🔧 What was happening
YouTube adds `start_radio=1` when starting a Mix. This flag causes
yt-dlp to return only one entry unless it is removed before extraction.

Additionally, the original Mix URL (with the flag still present) was used
to generate the cache filename, causing:
- inconsistent SHA256 cache hashes
- Mix playlists failing to expand
- duplicate cached playlist files

### ✔️ What this patch does
This PR normalizes Mix URLs *before* generating the cache filename and
before calling yt-dlp, by stripping:
- `&start_radio=1`
- `&start_radio=0`

This ensures:
- stable playlist caching
- correct Mix expansion
- full playlist playback with mpv

### 🧪 Testing
Tested on:
- Arch Linux  
- mpv + yt-dlp (latest)
- multiple Mix URLs (RD playlist)

Confirmed that:
- full Mix playlist expands correctly
- no duplicate caches are created
- playback works smoothly

Thanks for maintaining yt-x! 😊

