### PR TITLE
feat(nix): improve consumer interface

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenvNoCC,
+  makeWrapper,
+  yt-dlp,
+  jq,
+  fzf,
+  mpv,
+  ffmpeg,
+  gum,
+}:
+let
+  deps = [
+    yt-dlp
+    jq
+    fzf
+    mpv
+    ffmpeg
+    gum
+  ];
+in
+stdenvNoCC.mkDerivation {
+  pname = "yt-x";
+  version = "git";
+  src = ./.;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 yt-x -t $out/bin
+    wrapProgram $out/bin/yt-x \
+      --prefix PATH : ${lib.makeBinPath deps}
+
+    runHook postInstall
+  '';
+
+  meta.mainProgram = "yt-x";
+}

--- a/flake.nix
+++ b/flake.nix
@@ -7,9 +7,8 @@
   };
 
   outputs =
-    { nixpkgs, flake-utils, ... }:
+    { nixpkgs, flake-utils, self, ... }:
     flake-utils.lib.eachDefaultSystem (system: let
-      inherit (nixpkgs) lib;
       pkgs = nixpkgs.legacyPackages.${system};
       deps = with pkgs; [
         yt-dlp
@@ -21,20 +20,9 @@
       ];
     in
     {
-      packages.default = pkgs.stdenvNoCC.mkDerivation {
-        pname = "yt-x";
-        version = "git";
-        src = ./.;
-
-        nativeBuildInputs = [ pkgs.makeWrapper ];
-
-        installPhase = ''
-          install -Dm755 yt-x -t $out/bin
-          wrapProgram $out/bin/yt-x \
-            --prefix PATH : ${lib.makeBinPath deps}
-        '';
-
-        meta.mainProgram = "yt-x";
+      packages = {
+        default = self.packages.${system}.yt-x;
+        yt-x = pkgs.callPackage ./default.nix { };
       };
 
       devShells.${system}.default = pkgs.mkShellNoCC {

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
         yt-x = pkgs.callPackage ./default.nix { };
       };
 
-      devShells.${system}.default = pkgs.mkShellNoCC {
+      devShells.default = pkgs.mkShellNoCC {
         packages = deps;
       };
     });


### PR DESCRIPTION
Using `callPackage` to call the derivation allows consumers of the package to use a `.override` to override the inputs of the derivation. ie, a user may want to override the package to use a specific version of mpv with `yt-x.override { mpv = myMpv; }`, which will now work.

Having the derivation definition in a separate file also allows users who don't use flakes to easily import the derivation without needing flake-compat

The `devShells` output previously had a nested system attribute, meaning the devShell was at `devShells.${system}.${system}.default`. This was because of `flake-utils's` `eachDefaultSystem` adding the system attribute, as well as it being added manually.