### PR TITLE
update README.md with 'cannot decrypt cookies' error info

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ yt-dlp \
   "https://www.youtube.com/feed/channels" \
 ```
 
-In your tests, replace `brave+gnomekeyring:Default` with your browser and profile. For more details, refer to the [yt-dlp documentation](https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#general-options)
+In your tests, replace `brave+gnomekeyring:Default` with your browser and profile. For more details, refer to the [yt-dlp documentation](https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#general-options).
 
 > [!NOTE]
 > This is not an issue with yt-x itself, but rather with yt-dlp's ability to access browser cookies.


### PR DESCRIPTION
Proposes an addition tip in the `README.md` file to fix the "cannot decrypt cookies" error that may appear in certain browsers.