### PR TITLE
Fix ISO 8601 timestamp conversion in preview generation

### DIFF
--- a/yt-x
+++ b/yt-x
@@ -427,8 +427,17 @@ generate_text_preview() {
     ' -r)
 
     # some date calculations
-    timestamp=$(echo "$video" | jq '.timestamp' -r)
-    relative_timestamp=$(("$CURRENT_TIME" - "$timestamp"))
+    iso_timestamp=$(echo "$video" | jq '.timestamp' -r)
+    # convert ISO 8601 timestamp to Unix timestamp
+    case "$PLATFORM" in
+    mac)
+      timestamp=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$iso_timestamp" +%s 2>/dev/null || echo "$CURRENT_TIME")
+      ;;
+    *)
+      timestamp=$(date --date="$iso_timestamp" +%s 2>/dev/null || echo "$CURRENT_TIME")
+      ;;
+    esac
+    relative_timestamp=$((CURRENT_TIME - timestamp))
     if [ "$relative_timestamp" -lt 60 ]; then
       timestamp="just now"
     elif [ "$relative_timestamp" -lt 3600 ]; then


### PR DESCRIPTION
Hi everyone 👋

This PR solves an issue I was having with preview generation on macOS. Apparently the preview was failing due to some timestamp format mismatch between the YouTube API and the expected value on macOS.

To be fully transparent, the solution was one-shotted by Mistral AI. Looking at the resulted code I don't see obvious compatibility issues but I tested it on macOS only. Maybe someone should give it a try on other platforms before merging.

Here a rundown of the problem and solution.

## Problem

The script fails to generate previews with the error:

```bash
"1772663922"` - "1772636400": syntax error: operand expected
```

This occurs because YouTube API returns timestamps in ISO 8601 format (e.g., "2024-09-15T12:34:56Z"), but the script tries to perform arithmetic directly on these string values.

## Solution

Added cross-platform timestamp conversion that:
1.  Properly converts ISO 8601 timestamps to Unix timestamps
2.  Uses platform-appropriate date command syntax. macOS: `date -j -f "%Y-%m-%dT%H:%M:%SZ" "timestamp" +%s`. Linux/Other: `date --date="timestamp" +%s`
4.  Includes fallback to current time if conversion fails
5.  Fixes arithmetic syntax by removing unnecessary quotes