### PR TITLE
Fix output of desktop entry

### DIFF
--- a/yt-x
+++ b/yt-x
@@ -1900,18 +1900,15 @@ while [ $# -gt 0 ]; do
     shift
     ;;
   -E | --generate-desktop-entry)
-    echo "
-[Desktop Entry]
+    echo "[Desktop Entry]
 Name=$CLI_NAME
 Type=Application
-version=$CLI_VERSION
+X-Version=$CLI_VERSION
 Path=$HOME
 Comment=Browse Youtube from the terminal
-Terminal=false
-Icon=$CLI_DIR/assets/logo.png
-Exec=$0 --preferred-selector rofi
-Categories=Education
-    "
+Terminal=true
+Exec=$0
+Categories=Education"
     exit 0
     ;;
   completions)


### PR DESCRIPTION
The output was not a valid `.desktop` file since there was whitespace preceding the `[Desktop Entry]` line and the `version` key not beginning with `X-` to mark an extension.

Now it is possible to use e.g., `yt-x -E | tee ~/.local/share/applications/yt-x.desktop` to generate a `.desktop` file.

Let me know if you'd rather output the file directly, then you could use something akin to:
```sh
cat <<EOF > "$HOME/.local/share/applications/$CLI_NAME.desktop"
[Desktop Entry]
Name=$CLI_NAME
Type=Application
X-Version=$CLI_VERSION
Path=$HOME
Comment=Browse Youtube from the terminal
Terminal=true
Exec=$0
Categories=Education
EOF
```