### PR TITLE
fix: prevent printf error on video titles containing %

### DIFF
--- a/yt-x
+++ b/yt-x
@@ -998,7 +998,7 @@ ${RED}󰈆${RESET}  Exit" | launcher "Select Media Action" | sed 's/.  //g')"
         send_notification "Completed downloading of $playlist_name"
         ;;
       Listen)
-        printf "${MAGENTA}Now Listening to:${RESET} $title\n"
+        printf "${MAGENTA}Now Listening to:${RESET} %s\n" "$title"
         video_url=$(echo "$video" | jq '.url' -r)
         if echo "$video_url" | grep -q "list=RD"; then
           video_id=$(echo "$video" | jq '.id' -r | sed 's/RD//g')
@@ -1080,7 +1080,7 @@ ${RED}󰈆${RESET}  Exit" | launcher "Select Media Action" | sed 's/.  //g')"
         search_results="$_search_results"
         ;;
       Watch)
-        printf "${MAGENTA}Now watching:${RESET} $title\n"
+        printf "${MAGENTA}Now watching:${RESET} %s\n" "$title"
 
         video_url=$(echo "$video" | jq '.url' -r)
         if echo "$video_url" | grep -q "list=RD"; then


### PR DESCRIPTION
## Bug
https://github.com/Benexl/yt-x/issues/133 — Videos with `%` in the title cause a printf error and return to the menu instead of playing.

## Root Cause
In the Listen and Watch action handlers, the title is interpolated directly into the `printf` format string:
```bash
printf "${MAGENTA}Now Listening to:${RESET} $title\n"
```
When `$title` contains `%` (e.g. a title like `100% Pure`), `printf` interprets it as a format specifier (`%P`, `% `, etc.), which either produces garbage output or triggers a format error that terminates the command.

## Fix
Pass the title as a `%s` argument to `printf` instead of embedding it in the format string:
```bash
printf "${MAGENTA}Now Listening to:${RESET} %s\n" "$title"
```
This is the standard safe pattern — the format string is static and the variable data is passed as an argument, preventing any special character interpretation.

## Testing
Verified with the video from the issue report (`mqLMZjyIRFU`) and other titles containing `%`, `%%`, and `%s` — all display correctly without printf errors.

Happy to address any feedback.

Greetings, saschabuehrle