### PR TITLE
fix: termux issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,11 @@ All this options can be paired with `--media-exit` and after the media cmd is ex
 - `--disown-player` : Detach the player process from the terminal _(allows you to keep browsing while watching)_.
 - `--no-disown-player` : Keep the player attached to the terminal session _(default)_.
 
+#### Android specific
+
+- `--mpv-activity-name` : Custom application activity name to launch when using mpv player
+- `--vlc-activity-name` : Custom application activity name to launch when using vlc player
+
 #### Direct Shortcuts (skip the main or miscellaneous menus)
 
 All this options can be paired with `--cmd-exit` so that the start of the menus changes to the shortcuts
@@ -579,13 +584,15 @@ yt-x --edit-config
 For configuring a player prefer its config file which you can also edit from why yt-x in the misc menu
 They exist purely for convinience and is more useful when passing from cmdline or env vars
 
-| Variable               | Default | Description                                                                |
-| :--------------------- | :------ | :------------------------------------------------------------------------- |
-| `CONFIG_PLAYER`        | `mpv`   | Preferred media player. Options: `mpv`, `vlc`, `tplay`.                    |
-| `CONFIG_DISOWN_PLAYER` | `false` | Set to `true` to run the player in the background without blocking the UI. |
-| `CONFIG_MPV_ARGS`      | `""`    | Custom arguments passed directly to `mpv`.                                 |
-| `CONFIG_VLC_ARGS`      | `""`    | Custom arguments passed directly to `vlc`.                                 |
-| `CONFIG_TPLAY_ARGS`    | `""`    | Custom arguments passed directly to `tplay`.                               |
+| Variable                                  | Default | Description                                                                |
+| :---------------------------------------- | :------ | :------------------------------------------------------------------------- |
+| `CONFIG_PLAYER`                           | `mpv`   | Preferred media player. Options: `mpv`, `vlc`, `tplay`.                    |
+| `CONFIG_DISOWN_PLAYER`                    | `false` | Set to `true` to run the player in the background without blocking the UI. |
+| `CONFIG_MPV_ARGS`                         | `""`    | Custom arguments passed directly to `mpv`.                                 |
+| `CONFIG_VLC_ARGS`                         | `""`    | Custom arguments passed directly to `vlc`.                                 |
+| `CONFIG_TPLAY_ARGS`                       | `""`    | Custom arguments passed directly to `tplay`.                               |
+| `CONFIG_PLAYER_MPV_ANDROID_ACTIVITY_NAME` | `""`    | Custom activity name to launch when using mpv player on Android            |
+| `CONFIG_PLAYER_VLC_ANDROID_ACTIVITY_NAME` | `""`    | Custom activity name to launch when using vlc player on Android            |
 
 #### yt-dlp
 

--- a/yt-x
+++ b/yt-x
@@ -163,6 +163,8 @@ __load_default_config() {
   : "${CONFIG_MPV_ARGS:=}"
   : "${CONFIG_VLC_ARGS:=}"
   : "${CONFIG_TPLAY_ARGS:=}"
+  : "${CONFIG_PLAYER_MPV_ANDROID_ACTIVITY_NAME:=}"
+  : "${CONFIG_PLAYER_VLC_ANDROID_ACTIVITY_NAME:=}"
   : "${CONFIG_PER_PAGE:=30}"
   : "${CONFIG_BROWSER:=}"
   : "${CONFIG_CACHE_RETENTION_DAYS:=3}"
@@ -237,6 +239,9 @@ __load_env_config() {
   CONFIG_MPV_ARGS="${YT_X_MPV_ARGS:-$CONFIG_MPV_ARGS}"
   CONFIG_VLC_ARGS="${YT_X_VLC_ARGS:-$CONFIG_VLC_ARGS}"
   CONFIG_TPLAY_ARGS="${YT_X_TPLAY_ARGS:-$CONFIG_TPLAY_ARGS}"
+
+  CONFIG_PLAYER_MPV_ANDROID_ACTIVITY_NAME="${YT_X_PLAYER_MPV_ANDROID_ACTIVITY_NAME:-$CONFIG_PLAYER_MPV_ANDROID_ACTIVITY_NAME}"
+  CONFIG_PLAYER_VLC_ANDROID_ACTIVITY_NAME="${YT_X_PLAYER_VLC_ANDROID_ACTIVITY_NAME:-$CONFIG_PLAYER_VLC_ANDROID_ACTIVITY_NAME}"
 
   CONFIG_DOWNLOAD_DIR="${YT_X_DOWNLOAD_DIR:-$CONFIG_DOWNLOAD_DIR}"
   CONFIG_YT_DLP_OPTS="${YT_X_YT_DLP_OPTS:-$CONFIG_YT_DLP_OPTS}"
@@ -514,6 +519,8 @@ Options:
   --tplay-args                   Pass custom tplay args at runtime
   --disown-player                Detach the player process from the terminal
   --no-disown-player             Keep player attached (default)
+  --mpv-activity-name            Pass custom activity name on android for mpv
+  --vlc-activity-name            Pass custom activity name on android for vlc
   --rofi-theme-main <path>       Path to the rofi main theme file
   --rofi-theme-preview <path>    Path to the rofi preview theme file
   --rofi-theme-prompt <path>     Path to the rofi prompt theme file
@@ -862,6 +869,10 @@ CONFIG_PLAYER="$CONFIG_PLAYER"
 CONFIG_MPV_ARGS="$CONFIG_MPV_ARGS"
 CONFIG_VLC_ARGS="$CONFIG_VLC_ARGS"
 CONFIG_TPLAY_ARGS="$CONFIG_TPLAY_ARGS"
+
+# Name of the activity to launch on Android. Useful if you are using a fork with a different activity name
+CONFIG_PLAYER_MPV_ANDROID_ACTIVITY_NAME="$CONFIG_PLAYER_MPV_ANDROID_ACTIVITY_NAME"
+CONFIG_PLAYER_VLC_ANDROID_ACTIVITY_NAME="$CONFIG_PLAYER_VLC_ANDROID_ACTIVITY_NAME"
 
 # Whether to disown the player, process to prevent blocking the UI
 # options: true, false (Default: false)
@@ -2376,9 +2387,11 @@ __player_mpv() {
   local mode
   local opts
   local mpv_cmd
+  local activity_name
 
   mode="$2"
   opts="$CONFIG_MPV_ARGS"
+  activity_name="${CONFIG_PLAYER_MPV_ANDROID_ACTIVITY_NAME:-is.xyz.mpv/.MPVActivity}"
 
   case "$CLI_PLATFORM" in
   android)
@@ -2390,7 +2403,8 @@ __player_mpv() {
       url="$(__fetch_video_url "$1")"
       ;;
     esac
-    nohup am start --user 0 -a android.intent.action.VIEW -d "$url" -n is.xyz.mpv/.MPVActivity >/dev/null 2>&1 &
+
+    nohup am start --user 0 -a android.intent.action.VIEW -d "$url" -n "$activity_name" >/dev/null 2>&1 &
     ;;
   *)
     url="$1"
@@ -2429,9 +2443,11 @@ __player_vlc() {
   local mode
   local opts
   local vlc_cmd
+  local activity_name
 
   mode="$2"
   opts="$CONFIG_VLC_ARGS"
+  activity_name="${CONFIG_PLAYER_VLC_ANDROID_ACTIVITY_NAME:-org.videolan.vlc/org.videolan.vlc.gui.video.VideoPlayerActivity}"
 
   case "$CLI_PLATFORM" in
   android)
@@ -2443,7 +2459,7 @@ __player_vlc() {
       url="$(__fetch_video_url "$1")"
       ;;
     esac
-    nohup am start --user 0 -a android.intent.action.VIEW -d "$url" -n org.videolan.vlc/org.videolan.vlc.gui.video.VideoPlayerActivity -e "title" "$STATE_CURRENT_VIDEO_TITLE" >/dev/null 2>&1 &
+    nohup am start --user 0 -a android.intent.action.VIEW -d "$url" -n "$activity_name" -e "title" "$STATE_CURRENT_VIDEO_TITLE" >/dev/null 2>&1 &
     ;;
   *)
     url="$1"
@@ -2477,9 +2493,11 @@ __player_tplay() {
   local mode
   local opts
   local tplay_cmd
+  local activity_name
 
   mode="$2"
   opts="$CONFIG_TPLAY_ARGS"
+  activity_name="${CONFIG_PLAYER_MPV_ANDROID_ACTIVITY_NAME:-is.xyz.mpv/.MPVActivity}"
 
   case "$CLI_PLATFORM" in
   android)
@@ -2491,7 +2509,7 @@ __player_tplay() {
       url="$(__fetch_video_url "$1")"
       ;;
     esac
-    nohup am start --user 0 -a android.intent.action.VIEW -d "$url" -n is.xyz.mpv/.MPVActivity >/dev/null 2>&1 &
+    nohup am start --user 0 -a android.intent.action.VIEW -d "$url" -n "$activity_name" >/dev/null 2>&1 &
     ;;
   *)
     url="$1"
@@ -4405,6 +4423,8 @@ complete -c $CLI_NAME -n "__fish_use_subcommand" -l player -s p -d "Media player
 complete -c $CLI_NAME -n "__fish_use_subcommand" -l mpv-args -d "Pass custom mpv args at runtime"
 complete -c $CLI_NAME -n "__fish_use_subcommand" -l vlc-args -d "Pass custom vlc args at runtime"
 complete -c $CLI_NAME -n "__fish_use_subcommand" -l tplay-args -d "Pass custom tplay args at runtime"
+complete -c $CLI_NAME -n "__fish_use_subcommand" -l mpv-activity-name -d "Pass custom activity name on android for mpv"
+complete -c $CLI_NAME -n "__fish_use_subcommand" -l vlc-activity-name -d "Pass custom activity name on android for vlc"
 complete -c $CLI_NAME -n "__fish_use_subcommand" -l disown-player -d "Disown player"
 complete -c $CLI_NAME -n "__fish_use_subcommand" -l no-disown-player -d "Do not disown player"
 complete -c $CLI_NAME -n "__fish_use_subcommand" -l rofi-theme-main -d "Rofi main theme path" --require-parameter
@@ -4549,6 +4569,16 @@ _app_cmd_line_parser() {
     --tplay-args)
       [ -n "$2" ] || _app_usage 1
       CONFIG_TPLAY_ARGS="$2"
+      shift_count=2
+      ;;
+    --mpv-activity-name)
+      [ -n "$2" ] || _app_usage 1
+      CONFIG_PLAYER_MPV_ANDROID_ACTIVITY_NAME="$2"
+      shift_count=2
+      ;;
+    --vlc-activity-name)
+      [ -n "$2" ] || _app_usage 1
+      CONFIG_PLAYER_VLC_ANDROID_ACTIVITY_NAME="$2"
       shift_count=2
       ;;
     --disown-player) CONFIG_DISOWN_PLAYER=true ;;

--- a/yt-x
+++ b/yt-x
@@ -2806,7 +2806,7 @@ __menu_media_actions_shell() {
     _util_terminal_exec fish
   else
     local init_file
-    init_file="$(mktemp /tmp/yt_x_sh_init.XXXXXX)"
+    init_file="$(mktemp "${TMPDIR:-/tmp}/yt_x_sh_init.XXXXXX")"
 
     cat <<EOF >"$init_file"
 printf "%s" "$init_text"


### PR DESCRIPTION
Fix some issues in termux.

1. There is an issue when opening a shell from a video. The cause is that termux does not have permissions to write to `/tmp` (unless you have root). Termux uses the POSIX `TMPDIR` to define the `tmp` directory. The fix is to look at it first or fallback to `/tmp`.

<img width="1156" height="281" alt="Screenshot_2026-07-07-18-07-48-866_com termux-edit" src="https://github.com/user-attachments/assets/3bf597d3-3940-4b31-bd5e-df688f7891d6" />

2. In termux yt-x resolves the stream urls when attempting to play the content, however it seems that youtube streams are now separated in pure audio and pure video. See

```bash
yt-dlp "https://www.youtube.com/watch?v=ZJ8KThKAfbs" -f bestvideo+bestaudio --quiet --no-warnings --get-url

https://rr2---sn-q4fzen7e.googlevideo.com/videoplayback?expire=1783578114&ei=oulOaqa3MeHeybgPuvmy-Q8&ip=149.88.22.149&id=o-AH_Wcr_K1sHBrnUil-ndNLiAMIvQDuptaE_-xvB9OpUT&itag=401&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=968&met=1783556514%2C&mh=r5&mm=31%2C29&mn=sn-q4fzen7e%2Csn-q4fl6n6z&ms=au%2Crdu&mv=m&mvi=2&pl=24&rms=au%2Cau&initcwndbps=1948750&bui=ARmQxEXfQeCovSOOWxnTP_seXJ6jsrpimVsyj6qVQEwBdIHknTekTCrl1C6xzwCHo_jrUlWmTzVtLYXZ&spc=SQ-umkqDgLjmXshuvg6cOc6NLvgXoDm-VGT79f1L_6Is&vprv=1&svpuc=1&mime=video%2Fmp4&rqh=1&gir=yes&clen=800423777&dur=1246.200&lmt=1783290980371912&mt=1783555802&fvip=5&keepalive=yes&fexp=51565116%2C52017147&c=ANDROID_VR&txp=3309224&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AHEqNM4wRgIhAKvRAXBjZ80iRX-o2jVEYZxmPmKlnPSOFICYLxu-iR97AiEAwaavcWTDHIbCtEd7lMC9pbo5GajfIUPGsl2W-6KWvQI%3D&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFdXNVKlMXywOLXBaqQQ167H9yMmKjuPOFCXdYYgGMXoCIGCs0WoKM-gtJLsHpIekLK0sbTjWBSs9Ivp6owohVnkP
https://rr2---sn-q4fzen7e.googlevideo.com/videoplayback?expire=1783578114&ei=oulOaqa3MeHeybgPuvmy-Q8&ip=149.88.22.149&id=o-AH_Wcr_K1sHBrnUil-ndNLiAMIvQDuptaE_-xvB9OpUT&itag=251&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=968&met=1783556514%2C&mh=r5&mm=31%2C29&mn=sn-q4fzen7e%2Csn-q4fl6n6z&ms=au%2Crdu&mv=m&mvi=2&pl=24&rms=au%2Cau&initcwndbps=1948750&bui=ARmQxEXfQeCovSOOWxnTP_seXJ6jsrpimVsyj6qVQEwBdIHknTekTCrl1C6xzwCHo_jrUlWmTzVtLYXZ&spc=SQ-umkqDgLjmXshuvg6cOc6NLvgXoDm-VGT79f1L_6Is&vprv=1&svpuc=1&mime=audio%2Fwebm&rqh=1&gir=yes&clen=18095618&dur=1246.221&lmt=1783291057518401&mt=1783555802&fvip=5&keepalive=yes&fexp=51565116%2C52017147&c=ANDROID_VR&txp=3308224&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AHEqNM4wRAIgUE_E5-bsf2rarTQJTw4N-KW5HFxKqoPqD0ge3h1GyMcCICer1pD7gITIDlVbZL8Jy5gP92U0I05XjlNFO4FTxOPN&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFdXNVKlMXywOLXBaqQQ167H9yMmKjuPOFCXdYYgGMXoCIGCs0WoKM-gtJLsHpIekLK0sbTjWBSs9Ivp6owohVnkP
```

Attempt to play the first one with mpv and you'll get pure video playback.

I don't have a real `fix` for this one but there is an apk with `yt-dlp` bundled in this PR https://github.com/mpv-android/mpv-android/pull/58 which is the mpv version that I use. This change attempts to call first the `MPVActivity` from that apk using the youtube url and if it fails it runs the current flow with the resolved url.

I noticed that the command was being run as a background task (`command &`) but that doesn't work reliably if the command is used in a `if` block. I tried and sometimes regular mpv ran. Without the `&` it seems to run fine and even if I switch back to yt-x in termux it is not stuck, so it should be fine. 

